### PR TITLE
added syntaxhighlighting of string interpolations

### DIFF
--- a/julia.lang
+++ b/julia.lang
@@ -51,13 +51,34 @@
   </styles>
 
   <definitions>
+    <define-regex id="identifier">[_a-zA-Z][_a-zA-Z0-9]*</define-regex>
 
     <context id="string" style-ref="string" class="string" class-disabled="no-spell-check">
       <start>"</start>
       <end>"</end>
       <include>
         <context ref="def:escape" />
-      </include>
+        <context id="interpolation-with-parenthesis" style-ref="operator" extend-parent="true">
+          <start>\$\(</start>
+          <end>\)</end>
+          <include>
+            <context id="match-parenthesis-in-interpolate">
+              <start>\(</start>
+              <end>\)</end>
+              <include>
+                <context ref="match-parenthesis-in-interpolate"/>
+              </include>
+            </context>
+          </include>
+        </context>
+
+        <context id="interpolation" style-ref="operator" extend-parent="false">
+          <match extended="true">
+            \$
+            \%{identifier}
+          </match>
+        </context>
+      </include>	
     </context>
 
     <!--


### PR DESCRIPTION
I find it useful to be able to visually identify string interpolations in string, therefore I added a simple syntax highlighting for that to the language definition. 

It correctly handles string interpolations that start with parenthesis like `$(x*(y+z))` and those that only contains an alphanumeric identifier like `$x` or `$some_variable2` but not any valid unicode symbol like `$α`.

